### PR TITLE
fabric-builder-k8s moving to hyperledger-labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,4 @@ Deploy the chaincode package as usual, starting by installing the k8s chaincode 
 ```shell
 peer lifecycle chaincode install conga-nft-contract.tgz
 ```
+


### PR DESCRIPTION
Hi,

The fabric-builder-k8s repository is moving to hyperledger-labs! Unfortunately the move will mean rewriting the history of the main branch to add a couple of DCO sign-offs so if your fork has any un-merged commits, please let me know! After the move you'll need to update your main branch or re-fork the repository.

Regards, James

hyperledger-labs/hyperledger-labs.github.io#219